### PR TITLE
Use hash ID instead of Slack token in API requests 🔒

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -7,17 +7,22 @@ app.controller('MainController', ['$scope', '$http', '$mdToast', function($scope
     $scope.saving = false;
     $scope.plugins = [];
     $scope.token = "";
+    $scope.siriusId = "";
 
-    if(localStorage.slack_token){
+    if (localStorage.slack_token) {
         $scope.token = localStorage.slack_token;
+    }
+
+    if (localStorage.sirius_id) {
+        $scope.siriusId = localStorage.sirius_id;
     }
 
     $http.get(BASEPATH + '/plugins').then(function(res){
         console.log(res.data);
         $scope.plugins = res.data;
 
-        if($scope.token !== ""){
-            $http.get(BASEPATH + '/configs/' + $scope.token).then(function(res){
+        if($scope.siriusId !== ""){
+            $http.get(BASEPATH + '/configs/' + $scope.siriusId).then(function(res){
                 let config = res.data;
                 console.log(config);
                 for (var i = 0; i < $scope.plugins.length; i++) {
@@ -72,8 +77,9 @@ app.controller('MainController', ['$scope', '$http', '$mdToast', function($scope
 
         $http.post(BASEPATH + '/configs', $scope.generateConfig()).then(function(res){
             console.log(res);
+            localStorage.setItem('sirius_id', res.data.sirius_id);
             localStorage.setItem('slack_token', res.data.slack_token);
-            $mdToast.show($mdToast.simple().textContent('Successful save!'));
+            $mdToast.show($mdToast.simple().textContent('Registration saved successfully!'));
         }, function(res){
             alert('An error occured!');
         }).finally(function(){


### PR DESCRIPTION
This changes the API requests to use the new SHA-256 hash IDs.

**Related issues**
- https://github.com/kayex/sirius/issues/25 **Use ID hash instead of token in remote requests**
- https://github.com/adsa95/sirius-api/issues/8 **Don't use Slack tokens in URL**
